### PR TITLE
Add breakout detection mode for early viral tweet identification

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -6,7 +6,7 @@
 
 body {
   width: 320px;
-  height: 450px;
+  height: 600px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 14px;
   line-height: 1.4;
@@ -109,6 +109,50 @@ body {
   transform: translateX(20px);
 }
 
+/* Mode selector */
+.mode-selector {
+  margin-top: 16px;
+}
+
+.mode-title {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 10px;
+  color: #333;
+}
+
+.mode-options {
+  display: flex;
+  gap: 16px;
+}
+
+.mode-option {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.mode-option input[type="radio"] {
+  margin-right: 6px;
+  cursor: pointer;
+}
+
+.mode-text {
+  font-size: 13px;
+  color: #666;
+  cursor: pointer;
+}
+
+.mode-option:hover .mode-text {
+  color: #333;
+}
+
+.mode-option input[type="radio"]:checked + .mode-text {
+  color: #1da1f2;
+  font-weight: 500;
+}
+
 /* Legend section */
 .legend-section {
   border-bottom: 1px solid #e1e8ed;
@@ -156,6 +200,18 @@ body {
 
 .views-4-demo {
   background-color: #E74C3C;
+}
+
+.breakout-hot-demo {
+  background-color: #FF1E1E;
+}
+
+.breakout-warm-demo {
+  background-color: #FFC300;
+}
+
+.breakout-watch-demo {
+  background-color: #4A90E2;
 }
 
 .legend-text {
@@ -315,4 +371,80 @@ body {
   font-size: 12px;
   text-align: center;
   padding: 20px;
+}
+
+/* Guard rails section */
+.guard-rails-section {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid #e1e8ed;
+}
+
+.guard-rails-title {
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: #666;
+}
+
+.slider-group {
+  margin-bottom: 12px;
+}
+
+.slider-label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.slider-text {
+  font-size: 12px;
+  color: #666;
+  display: flex;
+  justify-content: space-between;
+}
+
+.slider {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 2px;
+  background: #e1e8ed;
+  outline: none;
+  transition: background 0.2s;
+}
+
+.slider:hover {
+  background: #d1d8dd;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #1da1f2;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.slider::-webkit-slider-thumb:hover {
+  transform: scale(1.1);
+  box-shadow: 0 2px 8px rgba(29, 161, 242, 0.3);
+}
+
+.slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #1da1f2;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s;
+}
+
+.slider::-moz-range-thumb:hover {
+  transform: scale(1.1);
+  box-shadow: 0 2px 8px rgba(29, 161, 242, 0.3);
 } 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -22,9 +22,23 @@
             <span class="toggle-slider"></span>
           </div>
         </label>
+        
+        <div class="mode-selector">
+          <h3 class="mode-title">Indicator Mode</h3>
+          <div class="mode-options">
+            <label class="mode-option">
+              <input type="radio" name="indicator-mode" value="views" id="mode-views" checked>
+              <span class="mode-text">View Count</span>
+            </label>
+            <label class="mode-option">
+              <input type="radio" name="indicator-mode" value="breakout" id="mode-breakout">
+              <span class="mode-text">Break-out Detection</span>
+            </label>
+          </div>
+        </div>
       </div>
       
-      <div class="legend-section">
+      <div class="legend-section" id="views-legend">
         <h3 class="legend-title">View Count Legend</h3>
         <div class="legend-items">
           <div class="legend-item">
@@ -42,6 +56,40 @@
           <div class="legend-item">
             <div class="legend-color views-4-demo"></div>
             <span class="legend-text">300K+ views</span>
+          </div>
+        </div>
+      </div>
+      
+      <div class="legend-section" id="breakout-legend" style="display: none;">
+        <h3 class="legend-title">🚀 Break-out Indicators</h3>
+        <div class="legend-items">
+          <div class="legend-item">
+            <div class="legend-color breakout-hot-demo"></div>
+            <span class="legend-text">🔥 Hot - High viral potential</span>
+          </div>
+          <div class="legend-item">
+            <div class="legend-color breakout-warm-demo"></div>
+            <span class="legend-text">⚡ Warm - Growing quickly</span>
+          </div>
+          <div class="legend-item">
+            <div class="legend-color breakout-watch-demo"></div>
+            <span class="legend-text">👀 Watch - Early momentum</span>
+          </div>
+        </div>
+        
+        <div class="guard-rails-section">
+          <h4 class="guard-rails-title">Guard Rails</h4>
+          <div class="slider-group">
+            <label class="slider-label">
+              <span class="slider-text">Max Views: <span id="max-views-value">100K</span></span>
+              <input type="range" id="max-views-slider" min="10000" max="500000" step="10000" value="100000" class="slider">
+            </label>
+          </div>
+          <div class="slider-group">
+            <label class="slider-label">
+              <span class="slider-text">Max Age: <span id="max-age-value">2h</span></span>
+              <input type="range" id="max-age-slider" min="30" max="360" step="30" value="120" class="slider">
+            </label>
           </div>
         </div>
       </div>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,9 +3,17 @@
  * Handles formats: "1,234", "5.6 K", "1.2 M"
  */
 export function parseViews(text: string): number | null {
+  return parseCount(text);
+}
+
+/**
+ * Generic count parser that handles various formats
+ * Handles formats: "1,234", "5.6 K", "1.2 M", "1.5 B"
+ */
+export function parseCount(text: string): number | null {
   if (!text) return null;
   
-  const match = text.match(/^([\d,.]+)\s*([KkMm])?$/);
+  const match = text.match(/^([\d,.]+)\s*([KkMmBb])?$/);
   if (!match) return null;
   
   const [, numberStr, suffix] = match;
@@ -13,7 +21,14 @@ export function parseViews(text: string): number | null {
   
   if (isNaN(baseNumber)) return null;
   
-  const multiplier = suffix ? (suffix.toLowerCase() === 'k' ? 1000 : 1000000) : 1;
+  let multiplier = 1;
+  if (suffix) {
+    const lowerSuffix = suffix.toLowerCase();
+    if (lowerSuffix === 'k') multiplier = 1000;
+    else if (lowerSuffix === 'm') multiplier = 1000000;
+    else if (lowerSuffix === 'b') multiplier = 1000000000;
+  }
+  
   return Math.floor(baseNumber * multiplier);
 }
 


### PR DESCRIPTION
Implements a velocity-based indicator system that identifies tweets gaining rapid engagement before they go viral. Users can toggle between traditional view count heat maps and the new breakout detection mode with customizable thresholds.

• Add metric extraction for replies/comments, reposts/retweets, likes from tweet aria-labels 
• Implement breakout score calculation using weighted engagement over time decay formula (S = 1.2R + 1.5Q + 1.0L / (t+1)^1.15) 
• Create three-tier indicator system with distinct colors (hot/warm/watch) using thicker 7px bars • Add mode selector in popup UI to switch between views and breakout indicators 
• Implement configurable guard rails with sliders for max views (10K-500K) and max age (30m-6h) • Store user preferences including mode and guard rail settings in chrome.storage.sync 
• Trigger automatic timeline repaint when settings change without page reload 
• Support both Twitter terminologies (replies/comments, reposts/retweets) for compatibility 
• Prevent visual overlap by making indicator modes mutually exclusive 
• Add per-tweet state tracking with automatic cleanup after 4 hours to prevent memory leaks

🤖 Generated with [Claude Code](https://claude.ai/code)